### PR TITLE
fix: restore PR CI workflows and disable paid-tier GCA

### DIFF
--- a/.github/workflows/gca.yml
+++ b/.github/workflows/gca.yml
@@ -1,9 +1,9 @@
 name: GCA Review
 
+# Disabled: requires paid GCA_TOKEN API access.
+# Re-enable pull_request trigger when GCA billing is configured.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: gca-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

- **Root cause**: The default branch was set to `wave2-lane-a-docs-unification`, which only had 2 workflow files. GitHub Actions reads `pull_request` triggers from the default branch, so most PR workflows were silently not firing.
- **Fix applied**: Reset default branch to `main` via API (`gh api -X PATCH repos/KooshaPari/heliosApp -f default_branch=main`)
- **Billing**: Disabled the GCA Review workflow's `pull_request` trigger (changed to `workflow_dispatch` only) since it requires a paid `GCA_TOKEN` API
- **Note**: The `Copilot code review` dynamic workflow also requires a Copilot subscription. To disable it, go to repo Settings > Copilot > disable code review. This cannot be done via API.

## Changes

- `.github/workflows/gca.yml`: Changed trigger from `pull_request` to `workflow_dispatch` only
- Default branch reset to `main` (API change, no file change)

## Test plan

- [ ] Open or re-push to an existing PR targeting `main`
- [ ] Verify all `pull_request`-triggered workflows now appear in the PR checks
- [ ] Verify GCA Review no longer auto-triggers on PRs

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions workflow configuration to use manual dispatch trigger instead of automatic pull request events.

---

**Note:** This release contains no user-facing changes. Updates are infrastructure-related only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->