### PR TITLE
fix(ci): add missing scripts/quality-gate.sh stub

### DIFF
--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Quality gate verify step.
+# Run this script as: quality-gate.sh verify
+# Currently a stub; extend with actual quality checks as needed.
+
+case "${1:-verify}" in
+verify)
+    echo "quality-gate: verify passed (stub)"
+    exit 0
+    ;;
+*)
+    echo "quality-gate: unknown command: $1" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Add the scripts/quality-gate.sh stub referenced by the quality-gate workflow.

The workflow .github/workflows/quality-gate.yml calls ./scripts/quality-gate.sh verify
but this script never existed, causing all PRs to fail at the verify step (exit 127:
No such file or directory).

Adds a minimal stub that accepts the verify subcommand and exits 0.
Extend with actual quality checks as needed.