### PR TITLE
fix: increase timeout for OrphanWatchdog CI polling tests

### DIFF
--- a/apps/runtime/tests/unit/lanes/watchdog/orphan_watchdog.test.ts
+++ b/apps/runtime/tests/unit/lanes/watchdog/orphan_watchdog.test.ts
@@ -63,7 +63,7 @@ describe("OrphanWatchdog", () => {
 
     // After stop, detection duration should be set
     expect(watchdog.getLastDetectionDuration()).toBeGreaterThanOrEqual(0);
-  });
+  }, 15000);
 
   it("should run detection cycles on interval", async () => {
     watchdog = new OrphanWatchdog({
@@ -92,7 +92,7 @@ describe("OrphanWatchdog", () => {
     expect(events[0].topic).toBe("orphan.detection.cycle_completed");
 
     watchdog.stop();
-  });
+  }, 15000);
 
   it("should emit detection cycle event with correct structure", async () => {
     watchdog = new OrphanWatchdog({
@@ -148,7 +148,7 @@ describe("OrphanWatchdog", () => {
     await watchdog.start();
 
     watchdog.stop();
-  });
+  }, 15000);
 
   it("should track detection duration", async () => {
     watchdog = new OrphanWatchdog({


### PR DESCRIPTION
## Summary
- Added `{ timeout: 15000 }` to all OrphanWatchdog tests that involve polling loops, timer waits, or async watchdog operations
- Three tests were missing the timeout: "should start and stop cleanly", "should run detection cycles on interval", and "should not allow double start"
- Two tests already had the timeout ("should emit detection cycle event" and "should track detection duration")
- Prevents CI timeouts at the default 5000ms threshold on slow runners

## Test plan
- [ ] Verify all 5 OrphanWatchdog tests pass in CI without timeout errors
- [ ] Confirm no test takes longer than 15s (generous bound for slow CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)