### PR TITLE
fix(ci): allow GitHub Update Branch merge commits in policy gate

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -39,9 +39,21 @@ jobs:
             exit 1
           fi
           if [[ -n "$MERGES" ]]; then
-            echo "ERROR: merge commits detected in PR diff range:"
-            echo "$MERGES"
-            exit 1
+            # Filter out merge commits from GitHub's "Update branch" button
+            # These have committer "GitHub <noreply@github.com>"
+            REAL_MERGES=""
+            while IFS= read -r sha; do
+              committer=$(git log -1 --format='%ce' "$sha" 2>/dev/null || echo "unknown")
+              if [[ "$committer" != "noreply@github.com" ]]; then
+                REAL_MERGES="${REAL_MERGES}${sha}"$'\n'
+              fi
+            done <<< "$MERGES"
+            REAL_MERGES=$(echo "$REAL_MERGES" | sed '/^$/d')
+            if [[ -n "$REAL_MERGES" ]]; then
+              echo "ERROR: merge commits detected in PR diff range:"
+              echo "$REAL_MERGES"
+              exit 1
+            fi
           fi
 
           echo "Policy gate passed."


### PR DESCRIPTION
## Summary
- Policy gate was rejecting all PRs updated via GitHub's Update Branch button
- Now filters out merge commits authored by GitHub (noreply@github.com)
- Only rejects merge commits from manual merges

## Test plan
- [ ] Verify dependabot PRs pass policy-gate after update-branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request merge-commit validation to exclude GitHub's automatic branch update commits, reducing false policy rejections while maintaining strict enforcement of intentional merge commit policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->