### PR TITLE
fix(ci): remove shallow fetch in policy-gate base ref

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -30,7 +30,7 @@ jobs:
 
           # Prevent merge commits in PR branch diff range
           PR_HEAD="${HEAD_SHA}"
-          if ! git fetch origin "$BASE_REF" --depth=1; then
+          if ! git fetch origin "$BASE_REF"; then
             echo "ERROR: failed to fetch base ref $BASE_REF."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Remove `--depth=1` from base ref fetch in policy-gate workflow
- The shallow fetch was breaking `git rev-list --merges` ancestry computation, causing merge commits in main's history to appear in the PR diff range
- This was blocking all dependabot PRs from merging

## Test plan
- [ ] Verify policy-gate passes on this PR itself
- [ ] Verify dependabot PRs pass policy-gate after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)