### PR TITLE
fix(ci): resolve merge conflicts and add missing permissions in CI workflows

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      security-events: write
 
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -69,7 +69,6 @@ jobs:
 
       - name: Gate 3 - Unit Tests
         id: gate-test
-<<<<<<< HEAD
         run: |
           set +e
           bun test apps/runtime apps/desktop/tests/unit scripts/tests/ | tee /tmp/test.log
@@ -80,9 +79,6 @@ jobs:
           if [ "$TEST_EXIT" -ne 0 ] || [ "$REPORT_EXIT" -ne 0 ]; then
             exit 1
           fi
-=======
-        run: bun run test
->>>>>>> origin/main
         timeout-minutes: 5
         continue-on-error: false
 
@@ -95,7 +91,7 @@ jobs:
           if ls apps/desktop/tests/e2e/*.spec.ts 1>/dev/null 2>&1; then
             bun run test:e2e
           else
-            echo "No e2e spec files found — skipping"
+            echo "No e2e spec files found -- skipping"
           fi
         timeout-minutes: 5
         continue-on-error: true
@@ -132,15 +128,11 @@ jobs:
 
       - name: Upload Gate Reports
         if: always()
-<<<<<<< HEAD
         run: bun run scripts/gate-aggregate.ts
 
       - name: Upload Gate Reports Artifact
         if: always()
         uses: actions/upload-artifact@v4
-=======
-        uses: actions/upload-artifact@v7
->>>>>>> origin/main
         with:
           name: gate-reports
           path: .gate-reports/

--- a/.github/workflows/vitepress-pages.yml
+++ b/.github/workflows/vitepress-pages.yml
@@ -48,14 +48,11 @@ jobs:
           bun-version: 1.2.20
 
       - name: Install dependencies
-<<<<<<< HEAD
         working-directory: heliosApp
         run: bun install
 
       - name: Install phenodocs dependencies
         working-directory: phenodocs
-=======
->>>>>>> origin/main
         run: bun install
 
       - name: Generate docs index


### PR DESCRIPTION
## Summary

- **quality-gates.yml**: Resolved two unresolved git merge conflicts. Kept the HEAD version of Gate 3 (uses `gate-test.ts` script runner for structured reporting) and the two-step gate reports upload (aggregate script + `upload-artifact@v4`).
- **vitepress-pages.yml**: Resolved merge conflict in the install dependencies section. Restored the correct split: separate `bun install` steps for the `heliosApp` and `phenodocs` working directories (required because both repos are checked out into named subdirectories).
- **compliance-check.yml**: Added missing `security-events: write` permission required by `anchore/sbom-action` for SARIF upload to GitHub Security tab.

## Root Cause

The `quality-gates.yml` and `vitepress-pages.yml` files were committed with unresolved `<<<<<<<`/`=======`/`>>>>>>>` git merge conflict markers, making the YAML invalid and causing the workflows to fail to parse entirely.

## Test plan

- [ ] Verify no conflict markers in active workflow files: `grep -rn "<<<<<<" .github/workflows/*.yml`
- [ ] Verify quality-gates.yml is valid YAML
- [ ] Verify vitepress-pages.yml is valid YAML
- [ ] Verify compliance-check.yml has `security-events: write` permission

Note: GitHub Actions CI will fail due to account billing limits; local YAML validation is the verification method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)