### PR TITLE
fix(ci): enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/vitepress-pages.yml
+++ b/.github/workflows/vitepress-pages.yml
@@ -1,4 +1,5 @@
 name: VitePress Pages
+# Pages enabled: KooshaPari/heliosApp - build_type=workflow
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

- Enable GitHub Pages with `build_type=workflow` via the API for `KooshaPari/heliosApp`
- The `vitepress-pages.yml` workflow was already structurally correct (proper permissions, `deploy-pages@v4`, correct artifact path)
- This commit triggers the initial deployment now that Pages is enabled

## Workflow verification
- Permissions: `pages: write`, `id-token: write`, `contents: read` — correct
- Uses `actions/deploy-pages@v4` — correct
- Build output: `heliosApp/docs/.vitepress/dist` — correct
- Bun install working-directory: `heliosApp` — correct

## Test plan
- [ ] Merge and verify the `VitePress Pages` workflow runs on push to main
- [ ] Confirm docs deploy to https://kooshapari.github.io/heliosApp/

🤖 Generated with [Claude Code](https://claude.com/claude-code)