### PR TITLE
fix(tests): increase timeout for storage size test and Bun test runner

### DIFF
--- a/apps/runtime/tests/integration/workspace/persistence.test.ts
+++ b/apps/runtime/tests/integration/workspace/persistence.test.ts
@@ -206,7 +206,7 @@ describe("Concurrent operations", () => {
 });
 
 describe("Storage size", () => {
-  test("50 workspaces with 10 projects each under 1 MB", async () => {
+  test("50 workspaces with 10 projects each under 1 MB", async () => { test.timeout(15000);
     const store = await createJsonStore(dataDir);
     for (let i = 0; i < 50; i++) {
       const ws = makeWorkspace({

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -15,3 +15,4 @@ save = true
 
 [test]
 preload = ["./apps/desktop/tests/unit/dom-shim.ts"]
+timeout = 30000


### PR DESCRIPTION
## Summary

Fixes CI test flakiness caused by slow test runner environments.

### Changes

1. **persistence.test.ts** — Adds `test.timeout(15000)` to the storage size test
   that was timing out on slower CI runners.

2. **bunfig.toml** — Adds global `[test] timeout = 30000` to give the Bun test
   runner enough headroom in constrained environments.

## Why

The storage size test (`50 workspaces with 10 projects each under 1 MB`) was
exceeding the default Bun test timeout on slower runners, causing spurious
CI failures unrelated to code correctness.