### PR TITLE
chore(secrets-scan): migrate gitleaks → trufflehog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Secrets scan (trufflehog)
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          extra_args: --only-verified
   ci-summary:
     name: ci-summary
     runs-on: ubuntu-latest

--- a/.github/workflows/stage-gates.yml
+++ b/.github/workflows/stage-gates.yml
@@ -116,11 +116,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Secrets scan (trufflehog)
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          extra_args: --only-verified
   e2e-smoke:
     name: e2e-smoke
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,6 +1,0 @@
-[allowlist]
-paths = [
-  '''__fixtures__/''',
-  '''__tests__/__fixtures__/''',
-  '''apps/runtime/src/secrets/__tests__/__fixtures__/known-secrets\.json''',
-]


### PR DESCRIPTION
## **User description**
## Summary

Replace `gitleaks` with `trufflehog` per Phenotype security tooling policy.
GitLeaks causes 20+ concurrent hung processes in multi-agent sessions and is
banned as of 2026-03-29.

## Changes

- Workflows + composite actions: `gitleaks/gitleaks-action@v2` → `trufflesecurity/trufflehog@main` with `extra_args: --only-verified`.
- Hooks (where present): swapped to `trufflehog git file://. --since-commit HEAD --only-verified --fail` using the `git rev-parse --git-common-dir` worktree-safe pattern.
- `.gitleaks.toml` / `.gitleaksignore` removed (trufflehog uses `--exclude-globs`).

## References

- Audit #114: gitleaks ban rationale
- Session #116: canonical pre-push hook template
- MEMORY: "Security Tooling: gitleaks → trufflehog (2026-03-29)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> CI security scanning behavior changes by swapping secret scanners, which could introduce false positives/negatives or CI breakage. Using `trufflesecurity/trufflehog@main` also increases supply-chain/upgrade risk compared to pinned versions.
> 
> **Overview**
> Replaces secret scanning in `ci.yml` and `stage-gates.yml` from `gitleaks/gitleaks-action@v2` to `trufflesecurity/trufflehog@main`, scanning the repo against the default branch and restricting results to *verified* findings via `--only-verified`.
> 
> Removes the now-unused `.gitleaks.toml` allowlist configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e735245d23b1474a4fed738133c32ee760e990ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Switch CI secret scanning to TruffleHog and remove the old GitLeaks config

### What Changed
- CI and stage-gate secret scans now use TruffleHog instead of GitLeaks
- Secret scans only report verified findings, which reduces noisy scan results
- The unused GitLeaks allowlist file was removed

### Impact
`✅ Fewer false secret-scan alerts`
`✅ Cleaner CI secret scan results`
`✅ Removed unused secret-scanning config`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=NlbasYbw8fISutlnN9_E0KtmHLX6SSZfj8Oi6pJA05A&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
