### PR TITLE
fix(firstrun): add dev/start/app scripts so bun run dev boots desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 HeliosApp is a developer-focused AI runtime environment with a desktop shell, terminal multiplexing, session management, and multi-provider AI inference. It is structured as a Bun monorepo containing four applications and five shared packages.
 
+## Quick Start
+
+```bash
+bun install && bun run dev
+```
+
+This boots the desktop shell (`apps/desktop`) in watch mode. Use `bun run dev:runtime` or `bun run dev:colab` to launch the runtime engine or colab renderer instead.
+
+> TODO: add desktop shell screenshot to README (`screenshot.png`).
+
 ---
 
 ## Architecture Overview

--- a/package.json
+++ b/package.json
@@ -14,6 +14,13 @@
   ],
   "type": "module",
   "scripts": {
+    "dev": "bun run --cwd apps/desktop dev",
+    "dev:desktop": "bun run --cwd apps/desktop dev",
+    "dev:runtime": "bun run --cwd apps/runtime dev",
+    "dev:colab": "bun run --cwd apps/colab-renderer dev",
+    "start": "bun run --cwd apps/desktop dev",
+    "app": "bun run --cwd apps/desktop dev",
+    "build": "bun run --cwd apps/desktop build && bun run --cwd apps/runtime build",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint apps/",
     "format": "biome format --write apps docs/.vitepress playwright.config.ts tsconfig.json package.json",


### PR DESCRIPTION
## Summary
- Adds top-level `dev`, `start`, `app` scripts to `package.json` so first-run evaluators (per `userstory-heliosapp-firstrun-2026-04-26.md`) can boot the desktop shell after `bun install`.
- Adds explicit `dev:desktop`, `dev:runtime`, `dev:colab` aliases plus a top-level `build` covering desktop + runtime.
- Adds Quick Start section to README near the top with `bun install && bun run dev` and a screenshot TODO.

## Verified dev command
`bun run dev` -> `bun run --cwd apps/desktop dev` -> `bun run --watch src/index.ts` (per `apps/desktop/package.json`).

## Test plan
- [ ] Fresh clone -> `bun install` -> `bun run dev` boots desktop watcher.
- [ ] `bun run dev:runtime` boots runtime engine.
- [ ] `bun run dev:colab` boots colab renderer.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates top-level `package.json` scripts and README documentation, with no runtime/business logic changes.
> 
> **Overview**
> Improves first-run developer experience by adding root-level Bun scripts so `bun run dev` (and `start`/`app`) launches the desktop shell from `apps/desktop`, with additional aliases for `dev:runtime` and `dev:colab` plus a combined `build`.
> 
> Updates the README with a **Quick Start** section documenting `bun install && bun run dev` and noting follow-up commands and a screenshot TODO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f01cfa7121950a725537729455c3cfae287fb74c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->