### PR TITLE
chore(gitignore): add .worktrees/ + .claude/worktrees/ entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ agileplus/
 .github/copilot-instructions.md
 .claudeignore
 .llmignore
+
+# Worktree directories (org policy)
+.worktrees/
+.claude/worktrees/


### PR DESCRIPTION
Per worktree-gitignore-coverage audit (2026-04-26).

Prevents phantom-gitlinks pattern by ensuring both worktree directory patterns are properly ignored.

Ref: repos/docs/governance/worktree-gitignore-coverage-2026-04-26.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to exclude additional local worktree directories, with no runtime or production code impact.
> 
> **Overview**
> Updates `.gitignore` to ignore org-standard worktree directories by adding `.worktrees/` and `.claude/worktrees/`, preventing these local worktree artifacts from being accidentally committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ca81540d8de3ff7234827f23e51566c1aba6fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->