### PR TITLE
Fix reusable workflow callers

### DIFF
--- a/.github/workflows/alert-sync-issues.yml
+++ b/.github/workflows/alert-sync-issues.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   sync:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable/alert-sync-issues.yml@6a6e1b06026e9443449e419a2892cd0e47c19442
+    uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@main
     with:
       auto-label: auto-alert-sync
       min_severity: medium

--- a/.github/workflows/security-guard-hook-audit.yml
+++ b/.github/workflows/security-guard-hook-audit.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   guard:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable/security-guard-hook-audit.yml@9bc51f34248d0bc4db5bc1dd7724a8398465eb47
+    uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@main

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -55,7 +55,7 @@ jobs:
             const approvals = {};
             reviews.data.forEach(review => {
               if (review.state === 'APPROVED') {
-                latestReviewByUser[review.user.login] = true;
+                approvals[review.user.login] = true;
               }
             });
 
@@ -137,7 +137,7 @@ jobs:
             core.setOutput('missing-requirements', missing.join('; '));
       
       - name: Comment on missing requirements
-        if: steps.check.outputs.can-self-merge == 'false' && (context.issue?.number || context.payload?.pull_request?.number)
+        if: steps.check.outputs.can-self-merge == 'false'
         uses: actions/github-script@v9
         with:
           script: |
@@ -165,7 +165,7 @@ jobs:
             });
 
       - name: Allow self-merge
-        if: steps.check.outputs.can-self-merge == 'true' && (context.issue?.number || context.payload?.pull_request?.number)
+        if: steps.check.outputs.can-self-merge == 'true'
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   tag:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable/tag-automation.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@main
     permissions:
       contents: write


### PR DESCRIPTION
## **User description**
## Summary
- point alert sync, hook audit, and tag automation at valid top-level phenoShared reusable workflows
- fix self-merge gate GitHub expression syntax and approval map assignment

## Validation
- actionlint .github/workflows/alert-sync-issues.yml .github/workflows/security-guard-hook-audit.yml .github/workflows/self-merge-gate.yml .github/workflows/tag-automation.yml

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> CI/workflow-only changes, but they affect security/audit and self-merge gating behavior, and switch reusable workflow references to `@main` (un-pinned), which could introduce unexpected future changes.
> 
> **Overview**
> Updates the reusable workflow callers for alert sync, security hook audit, and tag automation to reference the top-level `KooshaPari/phenoShared/.github/workflows/*.yml@main` paths instead of the prior `reusable/*` (and one pinned SHA) references.
> 
> Fixes the self-merge gate workflow by correcting the approval tracking map assignment and simplifying the `if:` expressions for the comment/allow steps so they run purely based on `can-self-merge` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ac6cdad895016e19c2781d613d080b70989f0d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix shared workflow references and restore self-merge checks**

### What Changed
- Alert sync, security hook audit, and tag automation now point to the correct shared workflow locations, so these automated jobs can run from the expected top-level workflows
- Self-merge gate now records approvals correctly, which restores accurate merge eligibility checks
- Self-merge comments now appear only when merge conditions are met or blocked, avoiding extra context checks that could prevent the workflow from running

### Impact
`✅ Working alert sync jobs`
`✅ Reliable security audit runs`
`✅ Accurate self-merge decisions`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Bn4PSuXB_IyOuUByXrUFb8MMHtwbGio79qgPimagohI&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
