### PR TITLE
Tighten Taskfile language detection

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,8 +3,10 @@ version: "3"
 vars:
   PROJECT_KIND:
     sh: |
-      if [ -f bun.lock ] || [ -f bun.lockb ] || [ -f package.json ]; then
+      if [ -f bun.lock ] || [ -f bun.lockb ] || { [ -f package.json ] && grep -q '"packageManager"[[:space:]]*:[[:space:]]*"bun@' package.json; }; then
         echo bun
+      elif [ -f package.json ]; then
+        echo node
       elif [ -f go.mod ]; then
         echo go
       elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
@@ -30,6 +32,9 @@ tasks:
           bun)
             bun run build
             ;;
+          node)
+            npm run build
+            ;;
           go)
             go build ./...
             ;;
@@ -53,6 +58,9 @@ tasks:
         case "{{.PROJECT_KIND}}" in
           bun)
             bun run test
+            ;;
+          node)
+            npm test
             ;;
           go)
             go test ./...
@@ -81,6 +89,9 @@ tasks:
         case "{{.PROJECT_KIND}}" in
           bun)
             bun run lint
+            ;;
+          node)
+            npm run lint
             ;;
           go)
             if command -v golangci-lint >/dev/null 2>&1; then


### PR DESCRIPTION
Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates task runner detection and adds `npm` command paths; impact is limited to local CI/dev workflows and could only affect which tooling is invoked.
> 
> **Overview**
> **Improves `Taskfile.yml` project detection** by treating a JS repo as `bun` only when Bun lockfiles exist or `package.json` explicitly declares `"packageManager": "bun@..."`, otherwise classifying it as `node`.
> 
> **Adds Node.js support** to `build`, `test`, and `lint` tasks by routing the new `node` kind to `npm run build`, `npm test`, and `npm run lint`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ced8033ed7d77fcb69db7dbd55fd498a102766f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->