### PR TITLE
Add detected language to common Taskfile tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,22 @@
 version: "3"
 
 vars:
-  PROJECT_KIND:
+  PROJECT_LANGUAGE:
+    sh: |
+      if [ -f tsconfig.json ] || [ -f tsconfig.base.json ]; then
+        echo typescript
+      elif [ -f package.json ]; then
+        echo javascript
+      elif [ -f go.mod ]; then
+        echo go
+      elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
+        echo python
+      elif [ -f Cargo.toml ]; then
+        echo rust
+      else
+        echo unknown
+      fi
+  PROJECT_TOOLCHAIN:
     sh: |
       if [ -f bun.lock ] || [ -f bun.lockb ] || { [ -f package.json ] && grep -q '"packageManager"[[:space:]]*:[[:space:]]*"bun@' package.json; }; then
         echo bun
@@ -26,14 +41,14 @@ tasks:
   language:
     desc: Print the detected project language/toolchain
     cmds:
-      - echo "{{.PROJECT_KIND}}"
+      - echo "{{.PROJECT_LANGUAGE}}/{{.PROJECT_TOOLCHAIN}}"
 
   build:
     desc: Build the project using detected language tooling
     cmds:
       - |
         set -euo pipefail
-        case "{{.PROJECT_KIND}}" in
+        case "{{.PROJECT_TOOLCHAIN}}" in
           bun)
             bun run build
             ;;
@@ -60,7 +75,7 @@ tasks:
     cmds:
       - |
         set -euo pipefail
-        case "{{.PROJECT_KIND}}" in
+        case "{{.PROJECT_TOOLCHAIN}}" in
           bun)
             bun run test
             ;;
@@ -91,7 +106,7 @@ tasks:
     cmds:
       - |
         set -euo pipefail
-        case "{{.PROJECT_KIND}}" in
+        case "{{.PROJECT_TOOLCHAIN}}" in
           bun)
             bun run lint
             ;;


### PR DESCRIPTION
## **User description**
Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: changes only task automation metadata and switches `build`/`test`/`lint` dispatch to use the existing toolchain detection logic, with no production code impact.
> 
> **Overview**
> Adds separate `PROJECT_LANGUAGE` detection (e.g., TypeScript vs JavaScript) alongside the existing `PROJECT_TOOLCHAIN` detection in `Taskfile.yml`.
> 
> Updates the `language` task to print `language/toolchain`, and switches `build`, `test`, and `lint` to branch on `PROJECT_TOOLCHAIN` (not a combined kind variable) so behavior aligns with the package manager/runtime actually in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e8312a97b14df3ba53ac03e118084b97aca2fda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Show the detected project language alongside the toolchain, and run common tasks using the toolchain**

### What Changed
- The `language` task now shows both the detected language and toolchain, making repository detection output easier to read
- `build`, `test`, and `lint` now choose commands based on the detected toolchain instead of the broader project type
- Language detection now distinguishes TypeScript from JavaScript while still covering Go, Python, and Rust

### Impact
`✅ Clearer project detection output`
`✅ Fewer wrong build/test/lint commands`
`✅ More reliable task runs in JavaScript and TypeScript projects`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=hWiGeoo4tEuQjxwMI8pEpSKblSiytnQHx8hlCffqjhU&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
