### PR TITLE
Improve Taskfile package manager detection

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,8 +20,12 @@ vars:
     sh: |
       if [ -f bun.lock ] || [ -f bun.lockb ] || { [ -f package.json ] && grep -q '"packageManager"[[:space:]]*:[[:space:]]*"bun@' package.json; }; then
         echo bun
-      elif [ -f package.json ]; then
-        echo node
+      elif [ -f pnpm-lock.yaml ] || { [ -f package.json ] && grep -q '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@' package.json; }; then
+        echo pnpm
+      elif [ -f yarn.lock ] || { [ -f package.json ] && grep -q '"packageManager"[[:space:]]*:[[:space:]]*"yarn@' package.json; }; then
+        echo yarn
+      elif [ -f package-lock.json ] || [ -f package.json ]; then
+        echo npm
       elif [ -f go.mod ]; then
         echo go
       elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
@@ -34,21 +38,39 @@ vars:
   BUILD_COMMAND:
     sh: |
       if [ -f package.json ] && node -e "process.exit(require('./package.json').scripts?.build ? 0 : 1)"; then
-        echo "bun run build"
+        case "{{.PROJECT_TOOLCHAIN}}" in
+          bun) echo "bun run build" ;;
+          pnpm) echo "pnpm run build" ;;
+          yarn) echo "yarn build" ;;
+          npm|node) echo "npm run build" ;;
+          *) echo "" ;;
+        esac
       else
         echo ""
       fi
   TEST_COMMAND:
     sh: |
       if [ -f package.json ] && node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
-        echo "bun run test"
+        case "{{.PROJECT_TOOLCHAIN}}" in
+          bun) echo "bun run test" ;;
+          pnpm) echo "pnpm run test" ;;
+          yarn) echo "yarn test" ;;
+          npm|node) echo "npm run test" ;;
+          *) echo "" ;;
+        esac
       else
         echo ""
       fi
   LINT_COMMAND:
     sh: |
       if [ -f package.json ] && node -e "process.exit(require('./package.json').scripts?.lint ? 0 : 1)"; then
-        echo "bun run lint"
+        case "{{.PROJECT_TOOLCHAIN}}" in
+          bun) echo "bun run lint" ;;
+          pnpm) echo "pnpm run lint" ;;
+          yarn) echo "yarn lint" ;;
+          npm|node) echo "npm run lint" ;;
+          *) echo "" ;;
+        esac
       else
         echo ""
       fi
@@ -70,15 +92,12 @@ tasks:
       - |
         set -euo pipefail
         case "{{.PROJECT_TOOLCHAIN}}" in
-          bun)
+          bun|pnpm|yarn|npm|node)
             if [ -z "{{.BUILD_COMMAND}}" ]; then
               echo "[FAIL] package.json does not define a build script"
               exit 1
             fi
             {{.BUILD_COMMAND}}
-            ;;
-          node)
-            npm run build
             ;;
           go)
             go build ./...
@@ -101,15 +120,12 @@ tasks:
       - |
         set -euo pipefail
         case "{{.PROJECT_TOOLCHAIN}}" in
-          bun)
+          bun|pnpm|yarn|npm|node)
             if [ -z "{{.TEST_COMMAND}}" ]; then
               echo "[FAIL] package.json does not define a test script"
               exit 1
             fi
             {{.TEST_COMMAND}}
-            ;;
-          node)
-            npm test
             ;;
           go)
             go test ./...
@@ -136,15 +152,12 @@ tasks:
       - |
         set -euo pipefail
         case "{{.PROJECT_TOOLCHAIN}}" in
-          bun)
+          bun|pnpm|yarn|npm|node)
             if [ -z "{{.LINT_COMMAND}}" ]; then
               echo "[FAIL] package.json does not define a lint script"
               exit 1
             fi
             {{.LINT_COMMAND}}
-            ;;
-          node)
-            npm run lint
             ;;
           go)
             if command -v golangci-lint >/dev/null 2>&1; then


### PR DESCRIPTION
## **User description**
Route common Taskfile tasks through the JavaScript package manager detected from repository manifests and lockfiles while preserving the existing Bun/TypeScript path for heliosApp.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Changes how `task build/test/lint` select and execute JavaScript package-manager commands, which can break CI/dev workflows if detection or script invocation differs across repos.
> 
> **Overview**
> **Improves JavaScript package manager detection in `Taskfile.yml`.** The `PROJECT_TOOLCHAIN` heuristic now distinguishes `bun`, `pnpm`, `yarn`, and `npm` using lockfiles and `package.json#packageManager`, defaulting to `npm` when `package.json` is present.
> 
> `task build`, `task test`, and `task lint` now route through toolchain-specific commands (`pnpm`, `yarn`, `npm`, or `bun`) derived from `BUILD_COMMAND`/`TEST_COMMAND`/`LINT_COMMAND`, replacing the previous Bun-first behavior and removing the separate `node` hardcoded branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 537c5f9230007693ba84796db6f62058f243d8ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Route Taskfile build, test, and lint commands through the repository’s package manager**

### What Changed
- JavaScript projects now run build, test, and lint tasks with the package manager they use: Bun, pnpm, Yarn, or npm.
- Repositories are recognized from lockfiles or the `packageManager` setting, and plain `package.json` projects now fall back to npm.
- Build, test, and lint keep working when the script exists, and they still fail with a clear message when the script is missing.

### Impact
`✅ Correct package manager commands for more JavaScript repos`
`✅ Fewer broken task runs in pnpm and Yarn projects`
`✅ Clearer build, test, and lint behavior in npm-based projects`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=u_ZC5ALGOceN18p5d3cXzVpzNZRPx1o5HguZ9mlTctQ&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
