### PR TITLE
Refine Taskfile common task detection

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,7 +37,7 @@ vars:
       fi
   BUILD_COMMAND:
     sh: |
-      if [ -f package.json ] && node -e "process.exit(require('./package.json').scripts?.build ? 0 : 1)"; then
+      if [ -f package.json ] && bun -e "const pkg = await import('./package.json', { with: { type: 'json' } }); process.exit(pkg.default.scripts?.build ? 0 : 1)"; then
         case "{{.PROJECT_TOOLCHAIN}}" in
           bun) echo "bun run build" ;;
           pnpm) echo "pnpm run build" ;;
@@ -50,7 +50,7 @@ vars:
       fi
   TEST_COMMAND:
     sh: |
-      if [ -f package.json ] && node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
+      if [ -f package.json ] && bun -e "const pkg = await import('./package.json', { with: { type: 'json' } }); process.exit(pkg.default.scripts?.test ? 0 : 1)"; then
         case "{{.PROJECT_TOOLCHAIN}}" in
           bun) echo "bun run test" ;;
           pnpm) echo "pnpm run test" ;;
@@ -63,7 +63,7 @@ vars:
       fi
   LINT_COMMAND:
     sh: |
-      if [ -f package.json ] && node -e "process.exit(require('./package.json').scripts?.lint ? 0 : 1)"; then
+      if [ -f package.json ] && bun -e "const pkg = await import('./package.json', { with: { type: 'json' } }); process.exit(pkg.default.scripts?.lint ? 0 : 1)"; then
         case "{{.PROJECT_TOOLCHAIN}}" in
           bun) echo "bun run lint" ;;
           pnpm) echo "pnpm run lint" ;;
@@ -87,7 +87,7 @@ tasks:
       - echo "{{.PROJECT_LANGUAGE}}/{{.PROJECT_TOOLCHAIN}}"
 
   build:
-    desc: Build the detected project
+    desc: Build the detected Bun/TypeScript project
     cmds:
       - |
         set -euo pipefail
@@ -115,7 +115,7 @@ tasks:
         esac
 
   test:
-    desc: Run the primary test suite for the detected project
+    desc: Run the primary Bun test suite
     cmds:
       - |
         set -euo pipefail
@@ -147,7 +147,7 @@ tasks:
         esac
 
   lint:
-    desc: Run static checks for the detected project
+    desc: Run the configured Bun lint checks
     cmds:
       - |
         set -euo pipefail


### PR DESCRIPTION
## **User description**
Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `Taskfile.yml` script-detection to run via `bun -e` instead of `node -e`, which may break build/test/lint task selection in environments without Bun installed. Otherwise the change is localized to developer tooling and task descriptions.
> 
> **Overview**
> Updates `Taskfile.yml` so `BUILD_COMMAND`, `TEST_COMMAND`, and `LINT_COMMAND` detect `package.json` scripts by executing a `bun -e` JSON import instead of `node -e`/`require`.
> 
> Also adjusts the `build`, `test`, and `lint` task descriptions to explicitly reference Bun/TypeScript (no behavioral changes beyond the updated detection logic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7505fee1a05b311199a8e528edf61e83ca72c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Detect package scripts with Bun and update task descriptions**

### What Changed
- Task detection for build, test, and lint now checks `package.json` through Bun before offering a command
- The build, test, and lint task descriptions now explicitly match the Bun-based workflow
- Projects without the matching script still return no command as before

### Impact
`✅ More reliable task detection in Bun projects`
`✅ Clearer task output for Bun users`
`✅ Fewer false task matches in script-based projects`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=OMOiqhCStJTah05MWrYVeErCvM2sriuWAGPxohOsSL4&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
